### PR TITLE
adding an `IamDataFrame.to_excel()` function

### DIFF
--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -537,8 +537,7 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
-    def to_excel(self, excel_writer, filters={}, exclude_cat=[],
-                 sheet_name='data', index=False, **kwargs):
+    def to_excel(self, excel_writer, sheet_name='data', index=False, **kwargs):
         """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
@@ -546,17 +545,12 @@ class IamDataFrame(object):
         ----------
         excel_writer: string or ExcelWriter object
              file path or existing ExcelWriter
-        filters: dict, optional
-            filter by model, scenario, region, variable, level, year, category
-            see function _select() for details
-        exclude_cat: None or list of strings, default []
-            exclude all scenarios from the listed categories
         sheet_name: string, default 'data'
             name of the sheet that will contain the (filtered) IamDataFrame
         index: boolean, default False
             write row names (index)
         """
-        df = self.filter(filters, exclude_cat).timeseries().reset_index()
+        df = self.timeseries().reset_index()
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -537,7 +537,8 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
-    def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
+    def to_excel(self, excel_writer, filters={}, exclude_cat=[],
+                 sheet_name='data', index=False, **kwargs):
         """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
@@ -550,17 +551,15 @@ class IamDataFrame(object):
             see function _select() for details
         exclude_cat: None or list of strings, default []
             exclude all scenarios from the listed categories
+        sheet_name: string, default 'data'
+            name of the sheet that will contain the (filtered) IamDataFrame
+        index: boolean, default False
+            write row names (index)
         """
         df = self.timeseries(filters, exclude_cat).reset_index()
         df.columns = [str.title(i) if type(i) == str else i
                       for i in df.columns]
-
-        defaults = {'sheet_name': 'data', 'index': False}
-        for key, value in defaults.items():
-            if key not in kwargs:
-                kwargs[key] = value
-
-        df.to_excel(excel_writer, **kwargs)
+        df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -556,9 +556,8 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries(filters, exclude_cat).reset_index()
-        df.columns = [str.title(i) if type(i) == str else i
-                      for i in df.columns]
+        df = self.filter(filters, exclude_cat).timeseries().reset_index()
+        df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -538,7 +538,7 @@ class IamDataFrame(object):
             return return_df(meta, display, idx_cols)
 
     def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
-        """Write timeseries data to Excel
+        """Write timeseries data to Excel using the IAMC template convention
         (wrapper for `pandas.DataFrame.to_excel()`)
 
         Parameters
@@ -554,7 +554,13 @@ class IamDataFrame(object):
         df = self.timeseries(filters, exclude_cat).reset_index()
         df.columns = [str.title(i) if type(i) == str else i
                       for i in df.columns]
-        df.to_excel(excel_writer, kwargs, index=False, sheet_name='data')
+
+        defaults = {'sheet_name': 'data', 'index': False}
+        for key, value in defaults.items():
+            if key not in kwargs:
+                kwargs[key] = value
+
+        df.to_excel(excel_writer, **kwargs)
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -309,20 +309,20 @@ class IamDataFrame(object):
         else:
             return df_pivot
 
-    def timeseries(self, filters={}, exclude_cat=['exclude']):
+    def timeseries(self, index=True):
         """Returns a dataframe in the standard IAMC format
 
         Parameters
         ----------
-        filters: dict, optional
-            filter by model, scenario, region, variable, level, year, category
-            see function _select() for details
-        exclude_cat: list of strings, default ['exclude']
-            exclude all scenarios from the listed categories from validation
+        index: boolean, default True
+            use IAMC columns as index (if True) or no index (if False)
         """
-        return self._select(filters, exclude_cat=exclude_cat
-                            ).pivot_table(index=iamc_idx_cols,
-                                          columns='year')['value']
+        df = self.data.pivot_table(index=iamc_idx_cols,
+                                   columns='year')['value']
+        if index is not True:
+            df.reset_index(inplace=True)
+
+        return df
 
     def validate(self, criteria, filters={}, exclude_cat=['exclude'],
                  exclude=False, silent=False, display='heatmap'):

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -536,6 +536,23 @@ class IamDataFrame(object):
                 meta = meta[keep_col_match(meta[col], values)]
             return return_df(meta, display, idx_cols)
 
+    def to_excel(self, excel_writer, filters={}, exclude_cat=[], **kwargs):
+        """Write timeseries data to Excel
+        (wrapper for `pandas.DataFrame.to_excel()`)
+
+        Parameters
+        ----------
+        excel_writer: string or ExcelWriter object
+             file path or existing ExcelWriter
+        filters: dict, optional
+            filter by model, scenario, region, variable, level, year, category
+            see function _select() for details
+        exclude_cat: None or list of strings, default []
+            exclude all scenarios from the listed categories
+        """
+        self.timeseries(filters, exclude_cat)\
+            .reset_index().to_excel(excel_writer, kwargs, index=False)
+
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -309,20 +309,11 @@ class IamDataFrame(object):
         else:
             return df_pivot
 
-    def timeseries(self, index=True):
+    def timeseries(self):
         """Returns a dataframe in the standard IAMC format
-
-        Parameters
-        ----------
-        index: boolean, default True
-            use IAMC columns as index (if True) or no index (if False)
         """
-        df = self.data.pivot_table(index=iamc_idx_cols,
+        return self.data.pivot_table(index=iamc_idx_cols,
                                    columns='year')['value']
-        if index is not True:
-            df.reset_index(inplace=True)
-
-        return df
 
     def validate(self, criteria, filters={}, exclude_cat=['exclude'],
                  exclude=False, silent=False, display='heatmap'):
@@ -550,7 +541,7 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries(index=False)
+        df = self.timeseries().reset_index()
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -509,7 +509,8 @@ class IamDataFrame(object):
         name: str, default None
             if df is series, name of new metadata column
         filters: dict, optional
-            filter by model, scenario or category
+            filter by model, scenario, region, variable, level, year, category
+            see function _select() for details
         idx_cols: list of str, default ['model', 'scenario']
             columns that are set as index of the returned dataframe (if 'list')
         exclude_cat: None or list of strings, default ['exclude']

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -550,7 +550,7 @@ class IamDataFrame(object):
         index: boolean, default False
             write row names (index)
         """
-        df = self.timeseries().reset_index()
+        df = self.timeseries(index=False)
         df = df.rename(columns={c: str(c).title() for c in df.columns})
         df.to_excel(excel_writer, sheet_name=sheet_name, index=index, **kwargs)
 

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -551,8 +551,10 @@ class IamDataFrame(object):
         exclude_cat: None or list of strings, default []
             exclude all scenarios from the listed categories
         """
-        self.timeseries(filters, exclude_cat)\
-            .reset_index().to_excel(excel_writer, kwargs, index=False)
+        df = self.timeseries(filters, exclude_cat).reset_index()
+        df.columns = [str.title(i) if type(i) == str else i
+                      for i in df.columns]
+        df.to_excel(excel_writer, kwargs, index=False, sheet_name='data')
 
     def interpolate(self, year, exclude_cat=['exclude']):
         """Interpolate missing values in timeseries (linear interpolation)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -40,7 +40,7 @@ def test_timeseries(test_ia):
            'years': [2005, 2010], 'value': [1, 6]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
-    obs = test_ia.timeseries({'variable': 'Primary Energy'})
+    obs = test_ia.filter({'variable': 'Primary Energy'}).timeseries()
     npt.assert_array_equal(obs, exp)
 
 
@@ -124,5 +124,5 @@ def test_interpolate():
            'years': [2005, 2007, 2010], 'value': [1, 3, 6]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
-    obs = df.timeseries({'variable': 'Primary Energy'})
+    obs = df.filter({'variable': 'Primary Energy'}).timeseries()
     npt.assert_array_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,7 +90,10 @@ def test_category_pass():
 
 
 def test_load_metadata(test_ia):
-    test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
+    with pytest.warns(Warning) as record:
+        test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
+    assert len(record) == 1
+
     obs = test_ia.metadata()
     dct = {'model': ['test_model'], 'scenario': ['test_scenario'],
            'category': ['imported']}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -93,6 +93,7 @@ def test_load_metadata(test_ia):
     with pytest.warns(Warning) as record:
         test_ia.load_metadata(os.path.join(here, 'testing_metadata.xlsx'))
     assert len(record) == 1
+    assert str(record[0].message) == 'overwriting 1 metadata entry'
 
     obs = test_ia.metadata()
     dct = {'model': ['test_model'], 'scenario': ['test_scenario'],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,6 +35,15 @@ def test_variable_unit(test_ia):
     npt.assert_array_equal(test_ia.variables(include_units=True), exp)
 
 
+def test_timeseries(test_ia):
+    dct = {'model': ['test_model'] * 2, 'scenario': ['test_scenario'] * 2,
+           'years': [2005, 2010], 'value': [1, 6]}
+    exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
+                                        columns=['years'], values='value')
+    obs = test_ia.timeseries({'variable': 'Primary Energy'})
+    npt.assert_array_equal(obs, exp)
+
+
 def test_validate_pass(test_ia):
     assert test_ia.validate(criteria='Primary Energy', exclude=True) is None
 

--- a/tutorial/pyam_first_steps.ipynb
+++ b/tutorial/pyam_first_steps.ipynb
@@ -20,7 +20,7 @@
     "see [data.ene.iiasa.ac.at/database](http://data.ene.iiasa.ac.at/database/) for more information.\n",
     "\n",
     "\n",
-    "| **model**           | **scenario**  | **region** | **variable**   | **unit** | **2005** | **2010** | **2015** |\n",
+    "| **Model**           | **Scenario**  | **Region** | **Variable**   | **Unit** | **2005** | **2010** | **2015** |\n",
     "|---------------------|---------------|------------|----------------|----------|----------|----------|----------|\n",
     "| MESSAGE V.4         | AMPERE3-Base  | World      | Primary Energy | EJ/y     | 454.5    |\t479.6    | ...      |\n",
     "| ...                 | ...           | ...        | ...            | ...      | ...      | ...      | ...      |\n",
@@ -33,6 +33,7 @@
     "0. Display of timeseries data as dataframe and visualization using simple plotting functions.\n",
     "0. Evaluating the model data and executing a range of diagnostic checks to identify data outliers.\n",
     "0. Categorization of scenarios according to timeseries data.\n",
+    "0. Exporting data to Excel\n",
     "\n",
     "\n",
     "## Tutorial data\n",
@@ -553,13 +554,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing data to Excel\n",
+    "\n",
+    "The IamDataFrame can be directly exported to Excel in the standard IAMC format.\n",
+    "This feature is based on [pandas.DataFrame.to_excel()](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_excel.html) and can use any keyword arguments of that function."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "df.to_excel('tutorial_export.xlsx')"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
In the spirit of making the IamDataFrame more similar to a `pandas.DataFrame`, and because I typed these two lines way to often...

This PR also adds a unit test for the `timeseries()` function and makes sure that one warning is raised when over-writing meta-data during the unit tests.