### PR TITLE
adding option to filter by metadata for boolean and integers

### DIFF
--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -21,6 +21,7 @@ from pyam_analysis.utils import (
     format_data,
     pattern_match,
     years_match,
+    isstr,
     META_IDX,
     IAMC_IDX
 )
@@ -57,7 +58,7 @@ class IamDataFrame(object):
         self.reset_exclude()
 
     def __getitem__(self, key):
-        _key_check = [key] if isinstance(key, six.string_types) else key
+        _key_check = [key] if isstr(key) else key
         if set(_key_check).issubset(self.meta.columns):
             return self.meta.__getitem__(key)
         else:
@@ -119,14 +120,13 @@ class IamDataFrame(object):
             output style for pivot table formatting
             accepts 'highlight_not_max', 'heatmap'
         """
-        index = [index] if isinstance(index, six.string_types) else index
-        columns = [columns] if isinstance(
-            columns, six.string_types) else columns
+        index = [index] if isstr(index) else index
+        columns = [columns] if isstr(columns) else columns
 
         df = self.data
 
         # allow 'aggfunc' to be passed as string for easier user interface
-        if isinstance(aggfunc, six.string_types):
+        if isstr(aggfunc):
             if aggfunc == 'count':
                 df = self.data.groupby(index + columns, as_index=False).count()
                 fill_value = 0

--- a/pyam_analysis/utils.py
+++ b/pyam_analysis/utils.py
@@ -96,7 +96,7 @@ def read_files(fnames, *args, **kwargs):
     """Read data from a snapshot file saved in the standard IAMC format
     or a table with year/value columns
     """
-    if isinstance(fnames, six.string_types):
+    if isstr(fnames):
         fnames = [fnames]
 
     fnames = itertools.chain(*[glob.glob(f) for f in fnames])
@@ -149,7 +149,7 @@ def style_df(df, style='heatmap'):
 
 def find_depth(data, s, level):
     # determine function for finding depth level =, >=, <= |s
-    if not isinstance(level, six.string_types):
+    if not isstr(level):
         test = lambda x: level == x
     elif level[-1] == '-':
         level = int(level[:-1])
@@ -178,7 +178,7 @@ def pattern_match(data, values, level=None):
 
     values = values if isinstance(values, list) else [values]
     for s in values:
-        if isinstance(s, six.string_types):
+        if isstr(s):
             regexp = (str(s)
                       .replace('|', '\\|')
                       .replace('*', '.*')

--- a/pyam_analysis/utils.py
+++ b/pyam_analysis/utils.py
@@ -5,6 +5,7 @@ import logging
 import six
 import re
 import glob
+import collections
 
 import numpy as np
 import pandas as pd
@@ -172,6 +173,9 @@ def pattern_match(data, values, level=None):
     to pseudo-regex for filtering by columns (str, int, bool)
     """
     matches = np.array([False] * len(data))
+    if not isinstance(values, collections.Iterable) and not isstr(values):
+        values = [values]
+
     values = values if isinstance(values, list) else [values]
     for s in values:
         if isinstance(s, six.string_types):
@@ -195,3 +199,10 @@ def years_match(data, years):
     """
     years = [years] if isinstance(years, int) else years
     return data.isin(years)
+
+
+def isstr(s):
+    """
+    check if it's  string
+    """
+    return True if isinstance(s, six.string_types) else False

--- a/pyam_analysis/utils.py
+++ b/pyam_analysis/utils.py
@@ -166,23 +166,26 @@ def find_depth(data, s, level):
     return list(map(apply_test, data))
 
 
-def pattern_match(data, strings, level=None):
+def pattern_match(data, values, level=None):
     """
     matching of model/scenario names, variables, regions, and categories
-    to pseudo-regex for filtering by columns (str)
+    to pseudo-regex for filtering by columns (str, int, bool)
     """
-    strings = [strings] if isinstance(strings, six.string_types) else strings
     matches = np.array([False] * len(data))
-    for s in strings:
-        regexp = (str(s)
-                  .replace('|', '\\|')
-                  .replace('*', '.*')
-                  .replace('+', '\+')
-                  ) + "$"
-        pattern = re.compile(regexp)
-        subset = filter(pattern.match, data)
-        depth = True if level is None else find_depth(data, s, level)
-        matches |= (data.isin(subset) & depth)
+    values = values if isinstance(values, list) else [values]
+    for s in values:
+        if isinstance(s, six.string_types):
+            regexp = (str(s)
+                      .replace('|', '\\|')
+                      .replace('*', '.*')
+                      .replace('+', '\+')
+                      ) + "$"
+            pattern = re.compile(regexp)
+            subset = filter(pattern.match, data)
+            depth = True if level is None else find_depth(data, s, level)
+            matches |= (data.isin(subset) & depth)
+        else:
+            matches |= data == s
     return matches
 
 

--- a/pyam_analysis/utils.py
+++ b/pyam_analysis/utils.py
@@ -173,10 +173,9 @@ def pattern_match(data, values, level=None):
     to pseudo-regex for filtering by columns (str, int, bool)
     """
     matches = np.array([False] * len(data))
-    if not isinstance(values, collections.Iterable) and not isstr(values):
+    if not isinstance(values, collections.Iterable) or isstr(values):
         values = [values]
 
-    values = values if isinstance(values, list) else [values]
     for s in values:
         if isstr(s):
             regexp = (str(s)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -265,3 +265,15 @@ def test_add_metadata_as_int(meta_df):
 
     obs = meta_df['meta_int']
     pd.testing.assert_series_equal(obs, exp)
+
+
+def test_filter_by_metadata_bool(meta_df):
+    meta_df.metadata([True, False], 'exclude')
+    obs = meta_df.filter({'exclude': True})
+    assert obs['scenario'].unique() == 'a_scenario'
+
+
+def test_filter_by_metadata_int(meta_df):
+    meta_df.metadata([1, 2], 'value')
+    obs = meta_df.filter({'value': [1, 3]})
+    assert obs['scenario'].unique() == 'a_scenario'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -268,12 +268,12 @@ def test_add_metadata_as_int(meta_df):
 
 
 def test_filter_by_metadata_bool(meta_df):
-    meta_df.metadata([True, False], 'exclude')
+    meta_df.metadata([True, False], name='exclude')
     obs = meta_df.filter({'exclude': True})
     assert obs['scenario'].unique() == 'a_scenario'
 
 
 def test_filter_by_metadata_int(meta_df):
-    meta_df.metadata([1, 2], 'value')
+    meta_df.metadata([1, 2], name='value')
     obs = meta_df.filter({'value': [1, 3]})
     assert obs['scenario'].unique() == 'a_scenario'


### PR DESCRIPTION
This PR reworks the `pattern_match()'  function to allow filtering by metadata when entries in the columns are boolean or integers.